### PR TITLE
Updated app embed names

### DIFF
--- a/crash-reporting/extensions/raygun-crash-reporting/blocks/raygun-cr.liquid
+++ b/crash-reporting/extensions/raygun-crash-reporting/blocks/raygun-cr.liquid
@@ -16,9 +16,8 @@
 
 {% schema %}
 {
-  "name": "Raygun Crash Reporting",
+  "name": "Crash Reporting",
   "target": "head",
-  "javascript": "crash-reporting.js",
   "settings": [
   {
     "type": "text",

--- a/real-user-monitoring/extensions/raygun-rum/blocks/raygun-rum.liquid
+++ b/real-user-monitoring/extensions/raygun-rum/blocks/raygun-rum.liquid
@@ -16,7 +16,7 @@
 
 {% schema %}
 {
-  "name": "Raygun Real User Monitoring",
+  "name": "Real User Monitoring",
   "target": "head",
   "settings": [
   {


### PR DESCRIPTION
## Description:
Removed the Raygun Prefix from the app embeds to conform to length requirements and remove the redundancy as it also will mention Raygun underneath the name when viewed in Shopify. I have also removed a reference to a javascript file that doesn't exist and I believe is a remnant from some previous testing