### PR TITLE
Prevent the raygun4js script from being loaded twice when both apps are installed and enabled

### DIFF
--- a/crash-reporting/extensions/raygun-crash-reporting/blocks/raygun-cr.liquid
+++ b/crash-reporting/extensions/raygun-crash-reporting/blocks/raygun-cr.liquid
@@ -1,15 +1,17 @@
 <script type="text/javascript">
-  !function(a,b,c,d,e,f,g,h){a.RaygunObject=e,a[e]=a[e]||function(){
-  (a[e].o=a[e].o||[]).push(arguments)},f=b.createElement(c),g=b.getElementsByTagName(c)[0],
-  f.async=1,f.src=d,g.parentNode.insertBefore(f,g),h=a.onerror,a.onerror=function(b,c,d,f,g){
-  h&&h(b,c,d,f,g),g||(g=new Error(b)),a[e].q=a[e].q||[],a[e].q.push({
-  e:g})}}(window,document,"script","//cdn.raygun.io/raygun4js/raygun.min.js","rg4js");
+  if(!window.rg4js){
+    !function(a,b,c,d,e,f,g,h){a.RaygunObject=e,a[e]=a[e]||function(){
+    (a[e].o=a[e].o||[]).push(arguments)},f=b.createElement(c),g=b.getElementsByTagName(c)[0],
+    f.async=1,f.src=d,g.parentNode.insertBefore(f,g),h=a.onerror,a.onerror=function(b,c,d,f,g){
+    h&&h(b,c,d,f,g),g||(g=new Error(b)),a[e].q=a[e].q||[],a[e].q.push({
+    e:g})}}(window,document,"script","//cdn.raygun.io/raygun4js/raygun.min.js","rg4js");
 
   {% if block.settings.raygun-api-key != blank %}
     rg4js('apiKey', '{{ block.settings.raygun-api-key }}');
   {% else %}
     rg4js('apiKey', '{{ shop.metafields.raygun.apikey }}');
   {% endif %}
+  }
  
   rg4js('enableCrashReporting', {{ block.settings.raygun-crash-reporting-enabled }});
 </script>

--- a/real-user-monitoring/extensions/raygun-rum/blocks/raygun-rum.liquid
+++ b/real-user-monitoring/extensions/raygun-rum/blocks/raygun-rum.liquid
@@ -1,15 +1,17 @@
 <script type="text/javascript">
-  !function(a,b,c,d,e,f,g,h){a.RaygunObject=e,a[e]=a[e]||function(){
-  (a[e].o=a[e].o||[]).push(arguments)},f=b.createElement(c),g=b.getElementsByTagName(c)[0],
-  f.async=1,f.src=d,g.parentNode.insertBefore(f,g),h=a.onerror,a.onerror=function(b,c,d,f,g){
-  h&&h(b,c,d,f,g),g||(g=new Error(b)),a[e].q=a[e].q||[],a[e].q.push({
-  e:g})}}(window,document,"script","//cdn.raygun.io/raygun4js/raygun.min.js","rg4js");
+  if(!window.rg4js){
+    !function(a,b,c,d,e,f,g,h){a.RaygunObject=e,a[e]=a[e]||function(){
+    (a[e].o=a[e].o||[]).push(arguments)},f=b.createElement(c),g=b.getElementsByTagName(c)[0],
+    f.async=1,f.src=d,g.parentNode.insertBefore(f,g),h=a.onerror,a.onerror=function(b,c,d,f,g){
+    h&&h(b,c,d,f,g),g||(g=new Error(b)),a[e].q=a[e].q||[],a[e].q.push({
+    e:g})}}(window,document,"script","//cdn.raygun.io/raygun4js/raygun.min.js","rg4js");
 
   {% if block.settings.raygun-api-key != blank %}
     rg4js('apiKey', '{{ block.settings.raygun-api-key }}');
   {% else %}
     rg4js('apiKey', '{{ shop.metafields.raygun.apikey }}');
   {% endif %}
+  }
 
   rg4js('enableRUM', {{ block.settings.raygun-real-user-monitoring-enabled }});
 </script>


### PR DESCRIPTION
## Description:
Adds a check to both embed apps to see if rg4js has already been initialized so that it isn't initialized twice. This way it doesn't matter which order the apps are added to the page.